### PR TITLE
Added stickyEnabled Input for ng-sticky-nav

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -117,6 +117,31 @@ stickyClass gives you the ability to assign a css class to your navbar when stic
 
 Now your nav will have a slight shadow when in sticky mode. This example can be useful for when your nav is the same color as the components it will be sitting on top of.
 
+###stickyEnabled
+
+stickyEnabled gives you the ability to toggle whether the navbar should stick based on external logic.
+
+```html
+<nav class="custom-nav-class" ngStickyNav [stickyEnabled]="customStickyLogic"></nav>
+```
+
+Note: If the condition changes, the element will only update after scrolling past it's original position.  For example, if stickyEnabled is true and the user scrolls past the element, it will become sticky.  If the condition changes to false, the element will remain sticky until it has returned to its original position, and subsequent scrolling will not cause the element to stick.
+
+
+```typescript
+/* sample.component.ts */
+
+export class sampleComponent{
+
+  customStickyLogic:boolean 
+  
+  ngDoCheck(){
+   this.customStickyLogic = this.performLogicCheck();
+  }
+}
+
+```
+
 ## License
 
 MIT © [Liam Stokinger](mailto:liamstokinger@gmail.com)

--- a/src/sticky-nav.directive.ts
+++ b/src/sticky-nav.directive.ts
@@ -2,66 +2,71 @@ import { Directive, Input, Renderer, ElementRef, OnInit, OnDestroy } from '@angu
 import { fromEvent, Subscription } from 'rxjs';
 
 @Directive({
-    selector: '[ngStickyNav]'
+  selector: '[ngStickyNav]'
 })
 
 export class StickyNavDirective implements OnInit, OnDestroy {
-    private originalPosition: number;
-    private lastScroll: number = 0;
-    private isSticky: boolean = false;
-    private scrollSubscription: Subscription;
-    private wrapper: HTMLElement;
-    @Input('stickyClass') stickyClass: string;
+  private originalPosition: number;
+  private lastScroll: number = 0;
+  private isSticky: boolean = false;
+  private scrollSubscription: Subscription;
+  private wrapper: HTMLElement;
+  @Input('stickyClass') stickyClass: string;
+  @Input() stickyEnabled: boolean = true;
 
-    constructor(private elementRef: ElementRef, private renderer: Renderer) {
+  constructor(private elementRef: ElementRef, private renderer: Renderer) {
 
+  }
+
+  ngOnInit(): void {
+    this.scrollSubscription = fromEvent(window, 'scroll').subscribe(() => this.manageScrollEvent());
+  }
+
+  private manageScrollEvent(): void {
+    const scroll = window.pageYOffset;
+    if (
+      this.stickyEnabled &&
+      scroll > this.lastScroll &&
+      !this.isSticky &&
+      scroll >= this.elementRef.nativeElement.offsetTop
+    ) {
+      this.setSticky();
+    } else if (scroll < this.lastScroll && this.isSticky && scroll <= this.originalPosition) {
+      this.unsetSticky();
     }
+    this.lastScroll = scroll;
+  }
 
-    ngOnInit(): void {
-        this.scrollSubscription = fromEvent(window, 'scroll').subscribe(() => this.manageScrollEvent());
+  private setSticky(): void {
+    this.isSticky = true;
+    this.originalPosition = this.elementRef.nativeElement.offsetTop;
+    this.wrapper = this.elementRef.nativeElement.cloneNode(true);
+    this.setStyle('position', 'fixed');
+    this.setStyle('top', '0');
+    this.setClass(true);
+    this.renderer.setElementStyle(this.wrapper, 'visibility', 'hidden');
+    this.elementRef.nativeElement.parentElement.insertBefore(this.wrapper, this.elementRef.nativeElement);
+  }
+
+  private unsetSticky(): void {
+    this.isSticky = false;
+    this.originalPosition = 0;
+    this.elementRef.nativeElement.parentElement.removeChild(this.wrapper);
+    this.setStyle('position', 'static');
+    this.setClass(false);
+  }
+
+  private setStyle(key: string, value: string): void {
+    this.renderer.setElementStyle(this.elementRef.nativeElement, key, value);
+  }
+
+  private setClass(add: boolean): void {
+    this.renderer.setElementClass(this.elementRef.nativeElement, this.stickyClass, add);
+  }
+
+  ngOnDestroy() {
+    if (this.scrollSubscription) {
+      this.scrollSubscription.unsubscribe();
     }
-
-    private manageScrollEvent(): void {
-        const scroll = window.pageYOffset;
-
-        if (scroll > this.lastScroll && !this.isSticky && scroll >= this.elementRef.nativeElement.offsetTop) {
-            this.setSticky();
-        } else if (scroll < this.lastScroll && this.isSticky && scroll <= this.originalPosition) {
-            this.unsetSticky();
-        }
-        this.lastScroll = scroll;
-    }
-
-    private setSticky(): void {
-        this.isSticky = true;
-        this.originalPosition = this.elementRef.nativeElement.offsetTop;
-        this.wrapper = this.elementRef.nativeElement.cloneNode(true);
-        this.setStyle('position', 'fixed');
-        this.setStyle('top', '0');
-        this.setClass(true);
-        this.renderer.setElementStyle(this.wrapper, 'visibility', 'hidden');
-        this.elementRef.nativeElement.parentElement.insertBefore(this.wrapper, this.elementRef.nativeElement);
-    }
-
-    private unsetSticky(): void {
-        this.isSticky = false;
-        this.originalPosition = 0;
-        this.elementRef.nativeElement.parentElement.removeChild(this.wrapper);
-        this.setStyle('position', 'static');
-        this.setClass(false);
-    }
-
-    private setStyle(key: string, value: string): void {
-        this.renderer.setElementStyle(this.elementRef.nativeElement, key, value);
-    }
-
-    private setClass(add: boolean): void {
-        this.renderer.setElementClass(this.elementRef.nativeElement, this.stickyClass, add);
-    }
-
-    ngOnDestroy() {
-        if (this.scrollSubscription) {
-            this.scrollSubscription.unsubscribe();
-        }
-    }
+  }
 }


### PR DESCRIPTION
Toggle sticky-ness based on provided logic.
Updated the README to include an example.

Wanted to add this to address a use case I encountered where I only needed sticky-nav enabled under certain circumstances and I wasn't able to use ng-templates.

@stokingerl (tagging just in case you don't see this)